### PR TITLE
Add emphasis node to disable the emphasis for line charts

### DIFF
--- a/src/main/java/edu/hm/hafner/echarts/Emphasis.java
+++ b/src/main/java/edu/hm/hafner/echarts/Emphasis.java
@@ -1,0 +1,23 @@
+package edu.hm.hafner.echarts;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Emphasis: currently we only need this to disable the emphasis for line charts.
+ *
+ * <p>
+ * This class will be automatically converted to a JSON object.
+ * </p>
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("FieldCanBeLocal")
+public class Emphasis {
+    @SuppressFBWarnings("SS_SHOULD_BE_STATIC")
+    @SuppressWarnings("FieldCanBeStatic")
+    private final boolean disabled = true;
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+}

--- a/src/main/java/edu/hm/hafner/echarts/LineSeries.java
+++ b/src/main/java/edu/hm/hafner/echarts/LineSeries.java
@@ -81,6 +81,11 @@ public class LineSeries {
         return itemStyle;
     }
 
+    @CheckForNull
+    public Emphasis getEmphasis() {
+        return filledMode == FilledMode.LINES ? new Emphasis() : null;
+    }
+
     /**
      * Adds a new build result to this series.
      *

--- a/src/main/java/edu/hm/hafner/echarts/line/LineSeries.java
+++ b/src/main/java/edu/hm/hafner/echarts/line/LineSeries.java
@@ -3,6 +3,7 @@ package edu.hm.hafner.echarts.line;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.echarts.AreaStyle;
+import edu.hm.hafner.echarts.Emphasis;
 import edu.hm.hafner.echarts.ItemStyle;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -102,6 +103,11 @@ public class LineSeries {
 
     public ItemStyle getItemStyle() {
         return itemStyle;
+    }
+
+    @CheckForNull
+    public Emphasis getEmphasis() {
+        return filledMode == FilledMode.LINES ? new Emphasis() : null;
     }
 
     /**


### PR DESCRIPTION
For line charts emphasis should be disabled as it distracts the visualization.